### PR TITLE
Update Dockerfile

### DIFF
--- a/gns3/docker/recorder/Dockerfile
+++ b/gns3/docker/recorder/Dockerfile
@@ -6,4 +6,4 @@ VOLUME  [ "/tcpdump" ]
 
 ENTRYPOINT [ "/usr/sbin/tcpdump" ]
 
-CMD [ "-C", "1000", "-v", "-i", "eth0", "-e", "-w", "/mnt/packet-data/packets.pcap" ]
+CMD [ "-C", "1000", "-v", "-i", "eth0", "-e", "$TCPD_EXTFILTER", "-w", "$TCPD_FILENAME" ]


### PR DESCRIPTION
Extendet tcpdump filter can be added with env "TCPD_EXTFILTER", e.g. TCPD_EXTFILTER="not arp" means, no ARP traffic will be captured.
Filename for output set with $TCPD_FILENAME