### PR TITLE
Simple dhcp and dns

### DIFF
--- a/gns3/projects/e20bb297-d8c6-4179-8b33-e9c63481ea6c/project-files/docker/0f1ab22e-4055-4ab4-9f8b-ba56ab12ffee/etc/network/interfaces
+++ b/gns3/projects/e20bb297-d8c6-4179-8b33-e9c63481ea6c/project-files/docker/0f1ab22e-4055-4ab4-9f8b-ba56ab12ffee/etc/network/interfaces
@@ -4,13 +4,13 @@
 
 
 # Static config for eth0
-auto eth0
-iface eth0 inet static
-	address 192.168.0.61
-	netmask 255.255.255.0
-	gateway 192.168.0.1
-	up echo nameserver 192.168.0.1 > /etc/resolv.conf
+#auto eth0
+#iface eth0 inet static
+#	address 192.168.0.3
+#	netmask 255.255.255.0
+#	gateway 192.168.0.1
+#	up echo nameserver 192.168.0.1 > /etc/resolv.conf
 
 # DHCP config for eth0
-# auto eth0
-# iface eth0 inet dhcp
+auto eth0
+iface eth0 inet dhcp

--- a/gns3/projects/e20bb297-d8c6-4179-8b33-e9c63481ea6c/project-files/docker/29d99eba-d48b-4dc6-b501-b1cd56648810/etc/network/interfaces
+++ b/gns3/projects/e20bb297-d8c6-4179-8b33-e9c63481ea6c/project-files/docker/29d99eba-d48b-4dc6-b501-b1cd56648810/etc/network/interfaces
@@ -4,13 +4,13 @@
 
 
 # Static config for eth0
-auto eth0
-iface eth0 inet static
-	address 192.168.0.203
-	netmask 255.255.255.0
-	gateway 192.168.0.1
-	up echo nameserver 192.168.0.1 > /etc/resolv.conf
+#auto eth0
+#iface eth0 inet static
+#	address 192.168.0.203
+#	netmask 255.255.255.0
+#	gateway 192.168.0.1
+#	up echo nameserver 192.168.0.1 > /etc/resolv.conf
 
 # DHCP config for eth0
-# auto eth0
-# iface eth0 inet dhcp
+auto eth0
+iface eth0 inet dhcp

--- a/gns3/projects/e20bb297-d8c6-4179-8b33-e9c63481ea6c/project-files/docker/309c8607-b534-40f7-945a-dc67580a4795/etc/network/interfaces
+++ b/gns3/projects/e20bb297-d8c6-4179-8b33-e9c63481ea6c/project-files/docker/309c8607-b534-40f7-945a-dc67580a4795/etc/network/interfaces
@@ -4,13 +4,13 @@
 
 
 # Static config for eth0
-auto eth0
-iface eth0 inet static
-	address 192.168.0.202
-	netmask 255.255.255.0
-	gateway 192.168.0.1
-	up echo nameserver 192.168.0.1 > /etc/resolv.conf
+#auto eth0
+#iface eth0 inet static
+#	address 192.168.0.202
+#	netmask 255.255.255.0
+#	gateway 192.168.0.1
+#	up echo nameserver 192.168.0.1 > /etc/resolv.conf
 
 # DHCP config for eth0
-# auto eth0
-# iface eth0 inet dhcp
+auto eth0
+iface eth0 inet dhcp

--- a/gns3/projects/e20bb297-d8c6-4179-8b33-e9c63481ea6c/project-files/docker/47fdec80-3c21-46b6-8090-a5ccb27523f0/etc/network/interfaces
+++ b/gns3/projects/e20bb297-d8c6-4179-8b33-e9c63481ea6c/project-files/docker/47fdec80-3c21-46b6-8090-a5ccb27523f0/etc/network/interfaces
@@ -4,13 +4,13 @@
 
 
 # Static config for eth0
-auto eth0
-iface eth0 inet static
-	address 192.168.0.201
-	netmask 255.255.255.0
-	gateway 192.168.0.1
-	up echo nameserver 192.168.0.1 > /etc/resolv.conf
+#auto eth0
+#iface eth0 inet static
+#	address 192.168.0.201
+#	netmask 255.255.255.0
+#	gateway 192.168.0.1
+#	up echo nameserver 192.168.0.1 > /etc/resolv.conf
 
 # DHCP config for eth0
-# auto eth0
-# iface eth0 inet dhcp
+auto eth0
+iface eth0 inet dhcp

--- a/gns3/projects/e20bb297-d8c6-4179-8b33-e9c63481ea6c/project-files/docker/a6f7fe1a-48f8-4a7d-a702-a90c81996b2e/etc/network/interfaces
+++ b/gns3/projects/e20bb297-d8c6-4179-8b33-e9c63481ea6c/project-files/docker/a6f7fe1a-48f8-4a7d-a702-a90c81996b2e/etc/network/interfaces
@@ -4,13 +4,13 @@
 
 
 # Static config for eth0
-auto eth0
-iface eth0 inet static
-	address 192.168.0.5
-	netmask 255.255.255.0
-	gateway 192.168.0.1
-	up echo nameserver 192.168.0.1 > /etc/resolv.conf
+#auto eth0
+#iface eth0 inet static
+#	address 192.168.0.5
+#	netmask 255.255.255.0
+#	gateway 192.168.0.1
+#	up echo nameserver 192.168.0.1 > /etc/resolv.conf
 
 # DHCP config for eth0
-# auto eth0
-# iface eth0 inet dhcp
+auto eth0
+iface eth0 inet dhcp

--- a/gns3/projects/e20bb297-d8c6-4179-8b33-e9c63481ea6c/project-files/docker/b3b4d141-c9ef-4a32-9a59-7dcb15d2a8ef/etc/network/interfaces
+++ b/gns3/projects/e20bb297-d8c6-4179-8b33-e9c63481ea6c/project-files/docker/b3b4d141-c9ef-4a32-9a59-7dcb15d2a8ef/etc/network/interfaces
@@ -4,13 +4,13 @@
 
 
 # Static config for eth0
-auto eth0
-iface eth0 inet static
-	address 192.168.0.12
-	netmask 255.255.255.0
-	gateway 192.168.0.1
-	up echo nameserver 192.168.0.1 > /etc/resolv.conf
+#auto eth0
+#iface eth0 inet static
+#	address 192.168.0.12
+#	netmask 255.255.255.0
+#	gateway 192.168.0.1
+#	up echo nameserver 192.168.0.1 > /etc/resolv.conf
 
 # DHCP config for eth0
-# auto eth0
-# iface eth0 inet dhcp
+auto eth0
+iface eth0 inet dhcp

--- a/gns3/projects/e20bb297-d8c6-4179-8b33-e9c63481ea6c/project-files/docker/cce0ed82-e83f-49bb-a522-a169578eb941/etc/network/interfaces
+++ b/gns3/projects/e20bb297-d8c6-4179-8b33-e9c63481ea6c/project-files/docker/cce0ed82-e83f-49bb-a522-a169578eb941/etc/network/interfaces
@@ -12,5 +12,5 @@
 #	up echo nameserver 192.168.0.1 > /etc/resolv.conf
 
 # DHCP config for eth0
-# auto eth0
-# iface eth0 inet dhcp
+auto eth0
+iface eth0 inet dhcp

--- a/gns3/projects/e20bb297-d8c6-4179-8b33-e9c63481ea6c/project-files/docker/dbaf30bf-a916-4391-8350-2f20783a156e/etc/network/interfaces
+++ b/gns3/projects/e20bb297-d8c6-4179-8b33-e9c63481ea6c/project-files/docker/dbaf30bf-a916-4391-8350-2f20783a156e/etc/network/interfaces
@@ -4,13 +4,13 @@
 
 
 # Static config for eth0
-auto eth0
-iface eth0 inet static
-	address 192.168.0.14
-	netmask 255.255.255.0
-	gateway 192.168.0.1
-	up echo nameserver 192.168.0.1 > /etc/resolv.conf
+#auto eth0
+#iface eth0 inet static
+#	address 192.168.0.14
+#	netmask 255.255.255.0
+#	gateway 192.168.0.1
+#	up echo nameserver 192.168.0.1 > /etc/resolv.conf
 
 # DHCP config for eth0
-# auto eth0
-# iface eth0 inet dhcp
+auto eth0
+iface eth0 inet dhcp

--- a/gns3/projects/e20bb297-d8c6-4179-8b33-e9c63481ea6c/project-files/docker/dd2ccfbd-a22d-4347-b58b-1c987d7c8db1/etc/network/interfaces
+++ b/gns3/projects/e20bb297-d8c6-4179-8b33-e9c63481ea6c/project-files/docker/dd2ccfbd-a22d-4347-b58b-1c987d7c8db1/etc/network/interfaces
@@ -4,13 +4,13 @@
 
 
 # Static config for eth0
-auto eth0
-iface eth0 inet static
-	address 192.168.0.6
-	netmask 255.255.255.0
-	gateway 192.168.0.1
-	up echo nameserver 192.168.0.1 > /etc/resolv.conf
+#auto eth0
+#iface eth0 inet static
+#	address 192.168.0.6
+#	netmask 255.255.255.0
+#	gateway 192.168.0.1
+#	up echo nameserver 192.168.0.1 > /etc/resolv.conf
 
 # DHCP config for eth0
-# auto eth0
-# iface eth0 inet dhcp
+auto eth0
+iface eth0 inet dhcp

--- a/gns3/projects/e20bb297-d8c6-4179-8b33-e9c63481ea6c/project-files/docker/dec79d29-1c9c-4a8a-9a05-8a3f972d7e83/etc/network/interfaces
+++ b/gns3/projects/e20bb297-d8c6-4179-8b33-e9c63481ea6c/project-files/docker/dec79d29-1c9c-4a8a-9a05-8a3f972d7e83/etc/network/interfaces
@@ -4,13 +4,13 @@
 
 
 # Static config for eth0
-auto eth0
-iface eth0 inet static
-	address 192.168.0.210
-	netmask 255.255.255.0
-	gateway 192.168.0.1
-	up echo nameserver 192.168.0.1 > /etc/resolv.conf
+#auto eth0
+#iface eth0 inet static
+#	address 192.168.0.210
+#	netmask 255.255.255.0
+#	gateway 192.168.0.1
+#	up echo nameserver 192.168.0.1 > /etc/resolv.conf
 
 # DHCP config for eth0
-# auto eth0
-# iface eth0 inet dhcp
+auto eth0
+iface eth0 inet dhcp

--- a/gns3/projects/e20bb297-d8c6-4179-8b33-e9c63481ea6c/project-files/docker/ea4bb36b-b64b-4bd5-a278-de70eb7e6e0b/etc/network/interfaces
+++ b/gns3/projects/e20bb297-d8c6-4179-8b33-e9c63481ea6c/project-files/docker/ea4bb36b-b64b-4bd5-a278-de70eb7e6e0b/etc/network/interfaces
@@ -4,13 +4,13 @@
 
 
 # Static config for eth0
-auto eth0
-iface eth0 inet static
-	address 192.168.0.4
-	netmask 255.255.255.0
-	gateway 192.168.0.1
-	up echo nameserver 192.168.0.1 > /etc/resolv.conf
+#auto eth0
+#iface eth0 inet static
+#	address 192.168.0.4
+#	netmask 255.255.255.0
+#	gateway 192.168.0.1
+#	up echo nameserver 192.168.0.1 > /etc/resolv.conf
 
 # DHCP config for eth0
-# auto eth0
-# iface eth0 inet dhcp
+auto eth0
+iface eth0 inet dhcp

--- a/gns3/projects/e20bb297-d8c6-4179-8b33-e9c63481ea6c/project-files/docker/f10dc491-cdb3-44e2-8acd-0c0df6e27df7/etc/network/interfaces
+++ b/gns3/projects/e20bb297-d8c6-4179-8b33-e9c63481ea6c/project-files/docker/f10dc491-cdb3-44e2-8acd-0c0df6e27df7/etc/network/interfaces
@@ -4,13 +4,13 @@
 
 
 # Static config for eth0
-auto eth0
-iface eth0 inet static
-	address 192.168.0.51
-	netmask 255.255.255.0
-	gateway 192.168.0.1
-	up echo nameserver 192.168.0.1 > /etc/resolv.conf
+#auto eth0
+#iface eth0 inet static
+#	address 192.168.0.2
+#	netmask 255.255.255.0
+#	gateway 192.168.0.1
+#	up echo nameserver 192.168.0.1 > /etc/resolv.conf
 
 # DHCP config for eth0
-# auto eth0
-# iface eth0 inet dhcp
+auto eth0
+iface eth0 inet dhcp

--- a/gns3/projects/e20bb297-d8c6-4179-8b33-e9c63481ea6c/project-files/docker/f9f66d30-b59e-4bbd-af56-8cb1dfd1b214/etc/network/interfaces
+++ b/gns3/projects/e20bb297-d8c6-4179-8b33-e9c63481ea6c/project-files/docker/f9f66d30-b59e-4bbd-af56-8cb1dfd1b214/etc/network/interfaces
@@ -4,13 +4,13 @@
 
 
 # Static config for eth0
-auto eth0
-iface eth0 inet static
-	address 192.168.0.102
-	netmask 255.255.255.0
-	gateway 192.168.0.1
-	up echo nameserver 192.168.0.1 > /etc/resolv.conf
+#auto eth0
+#iface eth0 inet static
+#	address 192.168.0.102
+#	netmask 255.255.255.0
+#	gateway 192.168.0.1
+#	up echo nameserver 192.168.0.1 > /etc/resolv.conf
 
 # DHCP config for eth0
-# auto eth0
-# iface eth0 inet dhcp
+auto eth0
+iface eth0 inet dhcp

--- a/gns3/projects/e20bb297-d8c6-4179-8b33-e9c63481ea6c/project-files/docker/f9f66d30-b59e-4bbd-af56-8cb1dfd1b214/etc/network/interfaces
+++ b/gns3/projects/e20bb297-d8c6-4179-8b33-e9c63481ea6c/project-files/docker/f9f66d30-b59e-4bbd-af56-8cb1dfd1b214/etc/network/interfaces
@@ -4,13 +4,13 @@
 
 
 # Static config for eth0
-#auto eth0
-#iface eth0 inet static
-#	address 192.168.0.102
-#	netmask 255.255.255.0
-#	gateway 192.168.0.1
-#	up echo nameserver 192.168.0.1 > /etc/resolv.conf
+auto eth0
+iface eth0 inet static
+	address 192.168.0.102
+	netmask 255.255.255.0
+	gateway 192.168.0.1
+	up echo nameserver 192.168.0.1 > /etc/resolv.conf
 
 # DHCP config for eth0
-auto eth0
-iface eth0 inet dhcp
+# auto eth0
+# iface eth0 inet dhcp

--- a/gns3/projects/e20bb297-d8c6-4179-8b33-e9c63481ea6c/project-files/dynamips/3e1755a3-df23-411e-84f8-f8e455f601b0/configs/i1_startup-config.cfg
+++ b/gns3/projects/e20bb297-d8c6-4179-8b33-e9c63481ea6c/project-files/dynamips/3e1755a3-df23-411e-84f8-f8e455f601b0/configs/i1_startup-config.cfg
@@ -1,16 +1,4 @@
 !
-!
-!
-!
-!
-!
-!
-!
-!
-!
-!
-
-!
 version 12.4
 service timestamps debug datetime msec
 service timestamps log datetime msec
@@ -28,7 +16,18 @@ no ip icmp rate-limit unreachable
 !
 !
 no ip cef
+ip host ssh-server 192.168.0.10
+ip host bot-server 192.168.0.200
 ip name-server 8.8.8.8
+no ip dhcp use vrf connected
+ip dhcp excluded-address 192.168.0.1
+ip dhcp excluded-address 192.168.0.10
+ip dhcp excluded-address 192.168.0.200
+!
+ip dhcp pool DHCPPool
+   network 192.168.0.0 255.255.255.0
+   default-router 192.168.0.1
+   dns-server 192.168.0.1
 !
 !
 !
@@ -48,23 +47,23 @@ ip name-server 8.8.8.8
 !
 !
 ip tcp synwait-time 5
-! 
+!
 !
 !
 !
 !
 interface FastEthernet0/0
  ip address dhcp
- ip nat enable
  ip nat outside
+ ip nat enable
  ip virtual-reassembly
  duplex auto
  speed auto
 !
 interface FastEthernet0/1
  ip address 192.168.0.1 255.255.255.0
- ip nat enable
  ip nat inside
+ ip nat enable
  ip virtual-reassembly
  duplex auto
  speed auto
@@ -74,12 +73,12 @@ no ip http server
 no ip http secure-server
 ip forward-protocol nd
 ip route 0.0.0.0 0.0.0.0 192.168.122.1
-access-list 10 permit 192.168.0.0 0.0.0.255
+!
+!
 ip nat inside source list 10 interface FastEthernet0/0 overload
-!
-!
 ip dns server
 !
+access-list 10 permit 192.168.0.0 0.0.0.255
 no cdp log mismatch duplex
 !
 !
@@ -107,4 +106,3 @@ line vty 0 4
 !
 !
 end
-


### PR DESCRIPTION
nachdem die dns lösung mit dnsmasq nicht funktioniert hat (hostname kam nie beim dhcp server an, ich glaub das liegt daran wie gns3 die docker container initialisiert) habe ich jetzt einen simplen dns server mit statischen routen zu den servern am cisco router eingestellt

- die container können die server über den hostnamen im router definierten hostnamen pingen (ist aber gleich wie der angezeigte)

- damit ein neuer server über den hostnamen angesprochen werden kann, muss am router ein weiterer ip host eintrag definiert werden und eine ausnahme für den dhcp pool gemacht werden

- die goldeneye container hab ich nicht geändert, da die nicht mit dem "hauptnetz" verbunden sind